### PR TITLE
Update package metadata and example Android build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2
+
+* Clean up package metadata for pub.dev
+* Update example Android/Kotlin Gradle configuration
+
 ## 0.1.1
 
 * Fix Material Card definition

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -13,10 +15,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -36,6 +34,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_17.toString())
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
+    id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,19 @@
 name: flutter_popup_card
 description: A Flutter plugin to create a card or custom widget that can popup overtop of your main app.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/jacksoncurrie/flutter_popup_card
 repository: https://github.com/jacksoncurrie/flutter_popup_card
-issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus
+issue_tracker: https://github.com/jacksoncurrie/flutter_popup_card/issues
+topics:
+  - flutter
+  - popup
+  - dialog
+  - overlay
+  - material
 
 environment:
   sdk: '>=3.1.1 <4.0.0'
-  flutter: ">=1.17.0"
+  flutter: '>=3.13.0'
 
 dependencies:
   flutter:
@@ -17,5 +23,3 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-
-flutter:


### PR DESCRIPTION
## Summary
- bump the package version to `0.1.2` and add a matching changelog entry
- fix pub.dev metadata by updating the issue tracker, adding topics, and aligning the minimum Flutter SDK with the Dart constraint
- update the example Android project to use Kotlin `compilerOptions`, bump AGP to `8.13.2`, and move the Gradle wrapper to `8.14.3`
- refresh `example/pubspec.lock` to capture the example app dependency updates

## Testing
- `flutter pub get`
- `flutter analyze`
- `./gradlew -q help` in `example/android`
- `flutter pub publish --dry-run`